### PR TITLE
Update Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,12 +5,12 @@ datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
-  planetScaleMode = true
+  referentialIntegrity = "prisma"
 }
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["planetScaleMode"]
+  previewFeatures = ["referentialIntegrity"]
 }
 
 model Post {


### PR DESCRIPTION
In the most recent Prisma release, `planetScaleMode` was removed in favor of this new `referentialIntegrity` feature preview. Your blog post would need to be updated with these changes as well 😊 

Ref https://github.com/prisma/prisma/issues/7292#issuecomment-925618707